### PR TITLE
Add the missing compiler application dependency.

### DIFF
--- a/ebin/dynamic_compile.app
+++ b/ebin/dynamic_compile.app
@@ -5,5 +5,5 @@
 		dynamic_compile
     ]},
     {registered, []},
-    {applications, [kernel, stdlib]}
+    {applications, [compiler, kernel, stdlib]}
 ]}.

--- a/ebin/dynamic_compile.app.in
+++ b/ebin/dynamic_compile.app.in
@@ -11,6 +11,6 @@ cat > ebin/dynamic_compile.app << EOF
 ${MODULES}
     ]},
     {registered, []},
-    {applications, [kernel, stdlib]}
+    {applications, [compiler, kernel, stdlib]}
 ]}.
 EOF


### PR DESCRIPTION
Not having this can cause problems with releases.
