### PR TITLE
Added functionality forms from string

### DIFF
--- a/src/dynamic_compile.erl
+++ b/src/dynamic_compile.erl
@@ -132,7 +132,7 @@ get_forms(CodeStr, CompileFormsOptions) ->
     %%      3. the directories specified using the i option. The directory specified last is searched first.
     %% In this case, #2 is meaningless.
     IncludeSearchPath = ["." | reverse([Dir || {i, Dir} <- CompileFormsOptions])],
-    scan_and_parse(CodeStr, Filename, 1, [], InitMD, IncludeSearchPath),
+    scan_and_parse(CodeStr, Filename, 1, [], InitMD, IncludeSearchPath).
 
 %%% Code from Mats Cronqvist
 %%% See http://www.erlang.org/pipermail/erlang-questions/2007-March/025507.html

--- a/src/dynamic_compile.erl
+++ b/src/dynamic_compile.erl
@@ -82,7 +82,7 @@ forms_from_string(CodeStr, CompileFormsOptions) ->
     %% In this case, #2 is meaningless.
     IncludeSearchPath = ["." | reverse([Dir || {i, Dir} <- CompileFormsOptions])],
     {RevForms, _OutMacroDict} = scan_and_parse(CodeStr, Filename, 1, [], InitMD, IncludeSearchPath),
-    Forms = reverse(RevForms),
+    reverse(RevForms).
 
 %%--------------------------------------------------------------------
 %% Function:


### PR DESCRIPTION
Forms from string functionality allows the programmer to further extend the imported code before compilation such as for example adding their own module name, attach functions, etc.
